### PR TITLE
refactor: remove redundant Init method from Plugins class

### DIFF
--- a/Qurre/Loader/Plugins.cs
+++ b/Qurre/Loader/Plugins.cs
@@ -21,11 +21,11 @@ internal static class Plugins
             ServerConsole.AddLog(ex.ToString(), ConsoleColor.Red);
         }
 
-        PatchMethods();
+PatchMethods();
 
-        LoadPlugins();
+LoadPlugins();
 
-        Internal.EventsManager.Loader.SortMethods();
+Internal.EventsManager.Loader.SortMethods();
         EnablePlugins();
 
         // TODO: не имеет смысла, потому что Timing.RunCoroutine
@@ -34,215 +34,215 @@ internal static class Plugins
         return;
 
         static IEnumerator<float> EnablePluginsInThread()
-        {
-            EnablePlugins();
-            yield break;
-        }
+{
+    EnablePlugins();
+    yield break;
+}
     }
 
     private static void PatchMethods()
+{
+    try
     {
+        bool errored = false;
+        _harmony = new Harmony("qurre.patches");
+
+        Type? reflectedType = new StackTrace().GetFrame(1)?.GetMethod()?.ReflectedType;
+        if (reflectedType is null)
+        {
+            Log.Error("Harmony Patching threw an error:\nReflectedType is null");
+            return;
+        }
+
+        Assembly assembly = reflectedType.Assembly;
+        AccessTools.GetTypesFromAssembly(assembly).Do(delegate (Type type)
+        {
+            try
+            {
+                _harmony.CreateClassProcessor(type).Patch();
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Excepted error in type: {BetterColors.Yellow(type)}\n{BetterColors.Grey(e)}");
+                errored = true;
+            }
+        });
+
+        if (!errored)
+            Log.Info("Harmony successfully Patched");
+    }
+    catch (Exception ex)
+    {
+        Log.Error($"Harmony Patching threw an error:\n{ex}");
+    }
+}
+
+private static void LoadDependencies()
+{
+    if (!Directory.Exists(Paths.Depends))
+        Directory.CreateDirectory(Paths.Depends);
+
+    List<string> files = [.. Directory.GetFiles(Paths.Depends)];
+
+    if (Paths.CustomDepends != Paths.Depends &&
+        Directory.Exists(Paths.CustomDepends))
+        files.AddRange(Directory.GetFiles(Paths.CustomDepends));
+
+    if (Directory.Exists(Paths.SystemDepends))
+        files.AddRange(Directory.GetFiles(Paths.SystemDepends));
+
+    foreach (string dll in files)
+    {
+        if (!dll.EndsWith(".dll") || Manager.Loaded(dll)) continue;
+
+        Assembly assembly = Manager.LoadAssembly(dll);
+
+        Log.Custom("Loaded dependency " + assembly.FullName, "Loader", ConsoleColor.Blue);
+    }
+
+    Log.Custom("Depends loaded", "Loader", ConsoleColor.Green);
+}
+
+private static void LoadPlugins()
+{
+    List<string> files = [.. Directory.GetFiles(Paths.Plugins)];
+
+    if (Paths.CustomPlugins != Paths.Plugins &&
+        Directory.Exists(Paths.CustomPlugins))
+        files.AddRange(Directory.GetFiles(Paths.CustomPlugins));
+
+    foreach (string plugin in files)
         try
         {
-            bool errored = false;
-            _harmony = new Harmony("qurre.patches");
-
-            Type? reflectedType = new StackTrace().GetFrame(1)?.GetMethod()?.ReflectedType;
-            if (reflectedType is null)
-            {
-                Log.Error("Harmony Patching threw an error:\nReflectedType is null");
-                return;
-            }
-
-            Assembly assembly = reflectedType.Assembly;
-            AccessTools.GetTypesFromAssembly(assembly).Do(delegate (Type type)
-            {
-                try
-                {
-                    _harmony.CreateClassProcessor(type).Patch();
-                }
-                catch (Exception e)
-                {
-                    Log.Error($"Excepted error in type: {BetterColors.Yellow(type)}\n{BetterColors.Grey(e)}");
-                    errored = true;
-                }
-            });
-
-            if (!errored)
-                Log.Info("Harmony successfully Patched");
+            Log.Debug($"Loading {plugin}");
+            Assembly assembly = Manager.LoadAssembly(plugin);
+            bool loaded = LoadPlugin(assembly);
+            if (loaded) Internal.EventsManager.Loader.PluginPath(assembly);
         }
         catch (Exception ex)
         {
-            Log.Error($"Harmony Patching threw an error:\n{ex}");
+            Log.Error($"An error occurred while loading {plugin}\n{ex}");
         }
-    }
+}
 
-    private static void LoadDependencies()
+private static bool LoadPlugin(Assembly assembly)
+{
+    try
     {
-        if (!Directory.Exists(Paths.Depends))
-            Directory.CreateDirectory(Paths.Depends);
-
-        List<string> files = [.. Directory.GetFiles(Paths.Depends)];
-
-        if (Paths.CustomDepends != Paths.Depends &&
-            Directory.Exists(Paths.CustomDepends))
-            files.AddRange(Directory.GetFiles(Paths.CustomDepends));
-
-        if (Directory.Exists(Paths.SystemDepends))
-            files.AddRange(Directory.GetFiles(Paths.SystemDepends));
-
-        foreach (string dll in files)
+        bool loaded = false;
+        foreach (Type type in assembly.GetTypes())
         {
-            if (!dll.EndsWith(".dll") || Manager.Loaded(dll)) continue;
+            PluginInit? attr = type.GetCustomAttribute<PluginInit>();
+            if (attr is null)
+                continue;
 
-            Assembly assembly = Manager.LoadAssembly(dll);
+            Log.Debug($"Loading plugin {attr.Name} ({type.FullName})");
 
-            Log.Custom("Loaded dependency " + assembly.FullName, "Loader", ConsoleColor.Blue);
-        }
+            loaded = true;
 
-        Log.Custom("Depends loaded", "Loader", ConsoleColor.Green);
-    }
+            PluginStruct plugin = new(attr);
 
-    private static void LoadPlugins()
-    {
-        List<string> files = [.. Directory.GetFiles(Paths.Plugins)];
-
-        if (Paths.CustomPlugins != Paths.Plugins &&
-            Directory.Exists(Paths.CustomPlugins))
-            files.AddRange(Directory.GetFiles(Paths.CustomPlugins));
-
-        foreach (string plugin in files)
-            try
+            foreach (MethodInfo methodInfo in type
+                         .GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public |
+                                     BindingFlags.NonPublic))
             {
-                Log.Debug($"Loading {plugin}");
-                Assembly assembly = Manager.LoadAssembly(plugin);
-                bool loaded = LoadPlugin(assembly);
-                if (loaded) Internal.EventsManager.Loader.PluginPath(assembly);
-            }
-            catch (Exception ex)
-            {
-                Log.Error($"An error occurred while loading {plugin}\n{ex}");
-            }
-    }
-
-    private static bool LoadPlugin(Assembly assembly)
-    {
-        try
-        {
-            bool loaded = false;
-            foreach (Type type in assembly.GetTypes())
-            {
-                PluginInit? attr = type.GetCustomAttribute<PluginInit>();
-                if (attr is null)
+                if (methodInfo.IsAbstract)
+                {
+                    Log.Debug($"Plugin Loader: '{methodInfo.Name}' is abstract, skip..");
                     continue;
-
-                Log.Debug($"Loading plugin {attr.Name} ({type.FullName})");
-
-                loaded = true;
-
-                PluginStruct plugin = new(attr);
-
-                foreach (MethodInfo methodInfo in type
-                             .GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public |
-                                         BindingFlags.NonPublic))
-                {
-                    if (methodInfo.IsAbstract)
-                    {
-                        Log.Debug($"Plugin Loader: '{methodInfo.Name}' is abstract, skip..");
-                        continue;
-                    }
-
-                    if (!methodInfo.IsStatic)
-                    {
-                        Log.Debug($"Plugin Loader: '{methodInfo.Name}' is non-static, skip..");
-                        continue;
-                    }
-
-                    if (methodInfo.GetCustomAttribute<PluginEnable>() is not null)
-                        plugin.EnableMethods.Add(new MethodStruct(methodInfo, attr, GetPriority(methodInfo)));
-
-                    if (methodInfo.GetCustomAttribute<PluginDisable>() is not null)
-                        plugin.DisableMethods.Add(new MethodStruct(methodInfo, attr, GetPriority(methodInfo)));
                 }
 
-                PluginsList.Add(plugin);
+                if (!methodInfo.IsStatic)
+                {
+                    Log.Debug($"Plugin Loader: '{methodInfo.Name}' is non-static, skip..");
+                    continue;
+                }
 
-                Log.Debug($"{type.FullName} loaded");
+                if (methodInfo.GetCustomAttribute<PluginEnable>() is not null)
+                    plugin.EnableMethods.Add(new MethodStruct(methodInfo, attr, GetPriority(methodInfo)));
 
-                Log.Custom(
-                    $"Plugin {plugin.Info.Name} written by {plugin.Info.Developer} loaded. v{plugin.Info.Version}",
-                    "Loader", ConsoleColor.Magenta);
+                if (methodInfo.GetCustomAttribute<PluginDisable>() is not null)
+                    plugin.DisableMethods.Add(new MethodStruct(methodInfo, attr, GetPriority(methodInfo)));
             }
 
-            if (!loaded)
-                Log.Debug($"{assembly.FullName} doesn't have a class with [PluginInit] attribute");
+            PluginsList.Add(plugin);
 
-            return loaded;
-        }
-        catch (Exception ex)
-        {
-            Log.Error($"An error occurred while loading {assembly.FullName}\n{ex}");
+            Log.Debug($"{type.FullName} loaded");
+
+            Log.Custom(
+                $"Plugin {plugin.Info.Name} written by {plugin.Info.Developer} loaded. v{plugin.Info.Version}",
+                "Loader", ConsoleColor.Magenta);
         }
 
-        return false;
+        if (!loaded)
+            Log.Debug($"{assembly.FullName} doesn't have a class with [PluginInit] attribute");
 
-        static int GetPriority(MethodInfo method)
-        {
-            PluginPriority? attr = method.GetCustomAttribute<PluginPriority>();
-            return attr?.Priority ?? 0;
-        }
+        return loaded;
+    }
+    catch (Exception ex)
+    {
+        Log.Error($"An error occurred while loading {assembly.FullName}\n{ex}");
     }
 
-    private static void EnablePlugins()
-    {
-        foreach (var method in PluginsList.SelectMany(ps => ps.EnableMethods).OrderByDescending(ms => ms.Priority))
-            try
-            {
-                method.MethodInfo.Invoke(null, []);
-                Log.Info(
-                    $"Plugin {method.Info.Name} [{method.MethodInfo.Name}] written by {method.Info.Developer} enabled. v{method.Info.Version}");
-            }
-            catch (Exception ex)
-            {
-                Log.Error(
-                    $"Plugin {method.Info.Name} [{method.MethodInfo.Name}] threw an exception while enabling\n{ex}");
-            }
-    }
+    return false;
 
-    private static void Disable()
+    static int GetPriority(MethodInfo method)
     {
-        foreach (var method in PluginsList.SelectMany(ps => ps.DisableMethods))
-            try
-            {
-                method.MethodInfo.Invoke(null, []);
-                Log.Info($"Plugin {method.Info.Name} [{method.MethodInfo.Name}] disabled");
-            }
-            catch (Exception ex)
-            {
-                Log.Error(
-                    $"Plugin {method.Info.Name} [{method.MethodInfo.Name}] threw an exception while disabling\n{ex}");
-            }
+        PluginPriority? attr = method.GetCustomAttribute<PluginPriority>();
+        return attr?.Priority ?? 0;
     }
+}
 
-    internal static void ReloadPlugins()
-    {
+private static void EnablePlugins()
+{
+    foreach (var method in PluginsList.SelectMany(ps => ps.EnableMethods).OrderByDescending(ms => ms.Priority))
         try
         {
-            Log.Info("Plugins are reloading...");
-
-            Disable();
-            Internal.EventsManager.Loader.UnloadPlugins();
-            PluginsList.Clear();
-
-            LoadPlugins();
-            EnablePlugins();
-            Internal.EventsManager.Loader.SortMethods();
-
-            Log.Info("Plugins reloaded");
+            method.MethodInfo.Invoke(null, []);
+            Log.Info(
+                $"Plugin {method.Info.Name} [{method.MethodInfo.Name}] written by {method.Info.Developer} enabled. v{method.Info.Version}");
         }
         catch (Exception ex)
         {
-            Log.Error($"Reload Plugins error..\n{ex}");
+            Log.Error(
+                $"Plugin {method.Info.Name} [{method.MethodInfo.Name}] threw an exception while enabling\n{ex}");
         }
+}
+
+private static void Disable()
+{
+    foreach (var method in PluginsList.SelectMany(ps => ps.DisableMethods))
+        try
+        {
+            method.MethodInfo.Invoke(null, []);
+            Log.Info($"Plugin {method.Info.Name} [{method.MethodInfo.Name}] disabled");
+        }
+        catch (Exception ex)
+        {
+            Log.Error(
+                $"Plugin {method.Info.Name} [{method.MethodInfo.Name}] threw an exception while disabling\n{ex}");
+        }
+}
+
+internal static void ReloadPlugins()
+{
+    try
+    {
+        Log.Info("Plugins are reloading...");
+
+        Disable();
+        Internal.EventsManager.Loader.UnloadPlugins();
+        PluginsList.Clear();
+
+        LoadPlugins();
+        EnablePlugins();
+        Internal.EventsManager.Loader.SortMethods();
+
+        Log.Info("Plugins reloaded");
     }
+    catch (Exception ex)
+    {
+        Log.Error($"Reload Plugins error..\n{ex}");
+    }
+}
 }

--- a/Qurre/Loader/Plugins.cs
+++ b/Qurre/Loader/Plugins.cs
@@ -16,19 +16,6 @@ internal static class Plugins
 {
     private static readonly List<PluginStruct> PluginsList = [];
     private static Harmony? _harmony;
-
-    internal static void Init()
-    {
-        if (!Directory.Exists(Paths.Plugins))
-        {
-            Log.Warn($"Plugins directory not found. Creating: {Paths.Plugins}");
-            Directory.CreateDirectory(Paths.Plugins);
-        }
-
-        try
-        {
-            LoadDependencies();
-        }
         catch (Exception ex)
         {
             ServerConsole.AddLog(ex.ToString(), ConsoleColor.Red);


### PR DESCRIPTION
The Init method has been removed because its functionality is no longer necessary or has been relocated, streamlining the Plugins class. Specifically, the directory check and LoadDependencies call are no longer performed during initialization, potentially simplifying setup or deferring these tasks elsewhere.